### PR TITLE
Rename project container to SymptomSync

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "COMP 426 Final Project Container",
+    "name": "SymptomSync Project Container",
     "dockerFile": "Dockerfile",
     
     // Forward ports


### PR DESCRIPTION
This pull request updates the name of the development container to better reflect the current project.

- Changed the `name` field in `.devcontainer/devcontainer.json` from "COMP 426 Final Project Container" to "SymptomSync Project Container" to match the project's current identity.