### PR TITLE
chore: update AI model from "gemini-1.5-flash" to "gemini-2.0-flash"

### DIFF
--- a/web/lib/aiChat.ts
+++ b/web/lib/aiChat.ts
@@ -42,7 +42,7 @@ export async function chatWithHealthAI(
 
   const genAI = new GoogleGenerativeAI(apiKey);
   const model = genAI.getGenerativeModel({
-    model: "gemini-1.5-flash",
+    model: "gemini-2.0-flash-lite",
     systemInstruction: defaultSystemInstruction,
   });
 


### PR DESCRIPTION
This pull request makes a minor update to the AI model used in the `chatWithHealthAI` function, switching to a newer, lighter version for improved performance.

- Updated the `model` parameter in the `chatWithHealthAI` function in `web/lib/aiChat.ts` from `"gemini-1.5-flash"` to `"gemini-2.0-flash-lite"` to use the latest available AI model.