### PR TITLE
fix: Remove Datadog APM auto-instrumentation from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,6 @@
   # copy the compiled bundle
   COPY --from=builder /app/web /app/web
   
-  # Datadog APM auto-instrumentation
-  RUN npm install --save dd-trace
-  ENV NODE_OPTIONS="--require dd-trace/init"
-  ENV DD_SERVICE=symptomsync-frontend
-  ENV DD_ENV=production
-
   EXPOSE 3000
   CMD ["npm", "start"]
   


### PR DESCRIPTION
This pull request removes Datadog APM auto-instrumentation from the Docker build for the frontend application. This simplifies the Dockerfile and removes the related dependencies and environment variables.

Removed Datadog APM integration:

* Eliminated installation of the `dd-trace` package and removal of related environment variables (`NODE_OPTIONS`, `DD_SERVICE`, `DD_ENV`) from the `Dockerfile`.