### PR TITLE
docs: add landing page screenshot to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Build with patient care in mind, **SymptomSync** is a web application designed t
 
 The UI of the app was designed with Figma and Tailwind CSS. The design is responsive and mobile-first, ensuring a seamless experience across devices. Below are some screenshots of the app in action:
 
+### Landing Page
+
+<p align="center">
+  <img src="docs/img/landing.png" alt="Landing Page Screenshot" width="100%"/>
+</p>
+
 ### Home Dashboard
 
 <p align="center">


### PR DESCRIPTION
This pull request updates the `README.md` file to enhance the project documentation by adding a visual example of the application's landing page.

Documentation improvements:

* Added a new "Landing Page" section with a centered screenshot (`docs/img/landing.png`) to showcase the app's initial interface.